### PR TITLE
Update to upstream release 0.3.0 / skip countdown if zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.3.0](https://github.com/DropMorePackets/berghain/compare/v0.2.0...v0.3.0) (2026-06-26)
+
+
+### Features
+
+* **web:** skip countdown if zero ([34abd33](https://github.com/DropMorePackets/berghain/commit/34abd334c4747bcafe63dd202a11da0b969a78fb))
+* **web:** toggle bootstrap elements ([d019e5a](https://github.com/DropMorePackets/berghain/commit/d019e5adcd4b1861d0848009f0406eee467fb8c4))
+
 ## [0.2.0](https://github.com/DropMorePackets/berghain/compare/v0.1.1...v0.2.0) (2025-06-18)
 
 

--- a/web/src/challange/loader.js
+++ b/web/src/challange/loader.js
@@ -50,6 +50,11 @@ export function stop(countdown, failed = false){
     setChallengeInfo("Challenge succeeded.");
     container.classList.add("alert-success");
 
+    if (countdown === 0){
+        setChallengeInfo("Reloading ...");
+        window.location.reload();
+    }
+
     const interval = setInterval(() => {
         setChallengeInfo(`Reloading in ${countdown}...`);
         if (countdown === 0){


### PR DESCRIPTION
Avoid superfluous "Reloading in ..." message if a countdown of zero is configured.

Upstream: https://github.com/DropMorePackets/berghain/pull/55